### PR TITLE
Audiobridge latency

### DIFF
--- a/src/portaudiovban.cpp
+++ b/src/portaudiovban.cpp
@@ -1,10 +1,14 @@
-#include "portaudiovbanserver.h"
+#include "portaudiovban.h"
 
 #ifdef __APPLESILICON__
     #include "pa_mac_core.h"
 #endif
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::audio::PortAudioVBANServer)
+    RTTI_CONSTRUCTOR(nap::Core&)
+RTTI_END_CLASS
+
+RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::audio::PortAudioVBANReceiver)
     RTTI_CONSTRUCTOR(nap::Core&)
 RTTI_END_CLASS
 
@@ -73,6 +77,7 @@ namespace nap
             }
         }
 
+
 #else
         PortAudioVBANServer::PortAudioVBANServer(Core &core) : VBANUDPServer(), mAudioService(*core.getService<PortAudioService>())
         {
@@ -80,6 +85,28 @@ namespace nap
         }
 
 #endif
+
+
+        PortAudioVBANReceiver::PortAudioVBANReceiver(Core &core) : VBANReceiver(core), mAudioService(*core.getService<audio::PortAudioService>())
+        {
+        }
+
+
+        bool PortAudioVBANReceiver::init(utility::ErrorState &errorState)
+        {
+            if (!VBANReceiver::init(errorState))
+                return false;
+
+            mAudioService.lateAudioCallback.connect(mLateAudioCallbackSlot);
+            return true;
+        }
+
+
+        void PortAudioVBANReceiver::onDestroy()
+        {
+            mAudioService.lateAudioCallback.disconnect(mLateAudioCallbackSlot);
+            VBANReceiver::onDestroy();
+        }
 
     }
 

--- a/src/portaudiovban.h
+++ b/src/portaudiovban.h
@@ -50,7 +50,7 @@ namespace nap
 
 
         /**
-         * Verison of the VBANReceiver that is tweaked for usage in combination with napportaudio.
+         * Version of the VBANReceiver that is tweaked for usage in combination with napportaudio.
          * When an audio callback is late it resets the actual latency in order to stay in sync with the sender.
          */
         class NAPAPI PortAudioVBANReceiver : public VBANReceiver

--- a/src/portaudiovban.h
+++ b/src/portaudiovban.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vbanudpserver.h>
+#include <vbanreceiver.h>
 #include <audio/service/portaudioservice.h>
 
 #ifdef __APPLE__
@@ -45,6 +46,27 @@ namespace nap
 
         private:
             audio::PortAudioService& mAudioService;
+        };
+
+
+        /**
+         * Verison of the VBANReceiver that is tweaked for usage in combination with napportaudio.
+         * When an audio callback is late it resets the actual latency in order to stay in sync with the sender.
+         */
+        class NAPAPI PortAudioVBANReceiver : public VBANReceiver
+        {
+        public:
+            PortAudioVBANReceiver(Core& core);
+
+            bool init(utility::ErrorState& errorState) override;
+            void onDestroy() override;
+
+            Slot<double> mLateAudioCallbackSlot = { this, &PortAudioVBANReceiver::onLateAudioCallback };
+            void onLateAudioCallback(double time) { getCircularBuffer()->reset(); }
+
+        private:
+            audio::PortAudioService& mAudioService;
+
         };
 
     }

--- a/src/vbancircularbuffer.cpp
+++ b/src/vbancircularbuffer.cpp
@@ -264,7 +264,7 @@ namespace nap
 	void VBANCircularBuffer::resetReadPosition()
 	{
 		double timeInMinutes = getNodeManager().getSampleTime() / (getNodeManager().getSamplesPerMillisecond() * 60000.f);
-		Logger::info("VBANCircularBuffer: resetting read position. Time: %f", timeInMinutes);
+		Logger::info("VBANCircularBuffer: resetting read position. Time: %.2f", timeInMinutes);
 		mReadPosition = mWritePosition - (mLatencyInBuffers.load() * getBufferSize());
 	}
 

--- a/src/vbancircularbuffer.cpp
+++ b/src/vbancircularbuffer.cpp
@@ -7,7 +7,7 @@
 namespace nap
 {
 
-	VBANCircularBuffer::VBANCircularBuffer(audio::NodeManager &nodeManager) : audio::Process(nodeManager)
+	VBANCircularBuffer::VBANCircularBuffer(audio::NodeManager &nodeManager, int size) : audio::Process(nodeManager), mSize(size)
 	{
 		mStreamName.reserve(VBAN_STREAM_NAME_SIZE);
 	}
@@ -249,12 +249,12 @@ namespace nap
 				resetReadPosition();
 			}
 
-			// // If the read position is too far behind, reset the latency.
-			// else if (mWritePosition - mReadPosition > (mLatencyInBuffers.load() * getBufferSize() * 3))
-			// {
-			// 	Logger::debug("VBANCircularBuffer: Read position too far behind.");
-			// 	resetReadPosition();
-			// }
+			// If the read position is too far behind, reset the latency.
+			else if (mWritePosition - mReadPosition > mSize)
+			{
+				Logger::debug("VBANCircularBuffer: Read position too far behind.");
+				resetReadPosition();
+			}
 
 			mLastWritePosition = mWritePosition;
 		}

--- a/src/vbancircularbuffer.h
+++ b/src/vbancircularbuffer.h
@@ -84,7 +84,7 @@ namespace nap
 		/**
 		 * Resets the actual latency to the latency as specified by setLatency().
 		 */
-		void recalibrate() { mResetReadPosition.set(); }
+		void reset() { mResetReadPosition.set(); }
 
 		/**
 		 * @return The number of streamd received in the circular buffer.

--- a/src/vbancircularbuffer.h
+++ b/src/vbancircularbuffer.h
@@ -23,7 +23,7 @@ namespace nap
 		 * Constructor
 		 * @param nodeManager The NodeManager of the system
 		 */
-		VBANCircularBuffer(audio::NodeManager& nodeManager);
+		VBANCircularBuffer(audio::NodeManager& nodeManager, int size = 8192);
 
 		// Called from control thread
 
@@ -129,7 +129,6 @@ namespace nap
 		std::atomic<int> mRealLatency = 0;
 		audio::DirtyFlag mResetReadPosition;			// This flag is set when the read position has to be recalculated from the write position.
 		std::atomic<int> mStreamCount = { 0 };			// Number of streams in the circular buffer.
-		static constexpr int MaxLatency = 2048;
 
 		// For error reporting
 		std::string mErrorMessage;

--- a/src/vbancircularbuffer.h
+++ b/src/vbancircularbuffer.h
@@ -73,18 +73,18 @@ namespace nap
 		/**
 		 * @return The latency in milliseconds, which is equal to the difference between the read and write position.
 		 */
-		float getLatency() const { return mLatency.load() / getNodeManager().getSamplesPerMillisecond(); }
+		float getLatency() const { return mRealLatency.load() / getNodeManager().getSamplesPerMillisecond(); }
 
 		/**
-		 * Sets the latency manually to a given amount instead of using calibration.
-		 * @param latency Latency in ms
+		 * Sets the latency as a multiplier of the buffersize
+		 * @param latency Latency as a multiplier of the buffersize.
 		 */
-		void setLatency(float latency);
+		void setLatency(int latency);
 
 		/**
-		 * Starts calibrating the latency by zeroing it and then increasing it for each bufer underrun or overflow.
+		 * Resets the actual latency to the latency as specified by setLatency().
 		 */
-		void calibrateLatency();
+		void recalibrate() { mResetReadPosition.set(); }
 
 		/**
 		 * @return The number of streamd received in the circular buffer.
@@ -100,6 +100,7 @@ namespace nap
 	private:
 		// Inherited from Process
 		void process() override;
+		void resetReadPosition(); // Called only by process()
 		void sampleRateChanged(float sampleRate) override { mResetReadPosition.set(); }
 		void bufferSizeChanged(int bufferSize) override { mResetReadPosition.set(); }
 
@@ -114,6 +115,7 @@ namespace nap
 		{
 			std::mutex mMutex;
 			audio::MultiSampleBuffer mData;
+			std::atomic<int> mPacketCounter = { 0 };
 		};
 		std::map<std::string, std::unique_ptr<ProtectedBuffer>> mBufferMap;
 		std::mutex mBufferMapMutex;						// Protects the buffer map.
@@ -121,17 +123,13 @@ namespace nap
 		int mSize = 8192;								// Size of the circular buffer in samples.
 		audio::DiscreteTimeValue mWritePosition = 0;	// Current write position in the circular buffer.
 		audio::DiscreteTimeValue mLastWritePosition = 0;
-		audio::DiscreteTimeValue mFadeInTime = 0;
 		nap::int64 mReadPosition = 0;					// The read position can be negative when the write position is zeroed.
 		std::string mStreamName;						// For internal use, kept here to avoid reallocations.
-		std::atomic<int> mLatency = 0;
-		std::atomic<int> mManualLatency = 0;
-		std::atomic<bool> mSetLatencyManually = { false };
+		std::atomic<int> mLatencyInBuffers = 0;
+		std::atomic<int> mRealLatency = 0;
 		audio::DirtyFlag mResetReadPosition;			// This flag is set when the read position has to be recalculated from the write position.
 		std::atomic<int> mStreamCount = { 0 };			// Number of streams in the circular buffer.
 		static constexpr int MaxLatency = 2048;
-
-		int mCounter = 0;
 
 		// For error reporting
 		std::string mErrorMessage;

--- a/src/vbanreceiver.cpp
+++ b/src/vbanreceiver.cpp
@@ -6,6 +6,7 @@
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::VBANReceiver)
     RTTI_CONSTRUCTOR(nap::Core&)
 	RTTI_PROPERTY("Server", &nap::VBANReceiver::mServer, nap::rtti::EPropertyMetaData::Required)
+	RTTI_PROPERTY("CircularBufferSize", &nap::VBANReceiver::mCircularBufferSize, nap::rtti::EPropertyMetaData::Default)
 RTTI_END_CLASS
 
 namespace nap

--- a/src/vbanreceiver.h
+++ b/src/vbanreceiver.h
@@ -19,6 +19,7 @@ namespace nap
 
     public:
         ResourcePtr<VBANUDPServer> mServer = nullptr; ///< Property: 'Server' Pointer to the VBAN UDP server receiving the packets
+        int mCircularBufferSize = 8192; ///< Property: 'CircularBufferSize' Size of the circular buffer
 
         /**
          * Constructor


### PR DESCRIPTION
Import updates audio bridge: 
- latency is specified in buffers again 
- actual latency as difference in read and write pointer is displayed in UI.
- the read pointer is being reset on a skipped/late audiocallback
- no more maximum latency: the actual latency remains stable!

Tweaks to make parallel processing more stable:
- lockfree parallelization
- only the particles are parallelized
- The number of audio threads is 16, a good standard for parallel processing